### PR TITLE
Fixed IPython "TraitError" compatibility issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ sc = LDPSetCreator(teff=(6400,   50),    # Define your star, and the code
                    filters=filters)      # FTP server automatically.
 
 ps = sc.create_profiles()                # Create the limb darkening profiles
-cq,eq = ps.coeffs_qd(use_mc=True)        # Estimate quadratic law coefficients
+cq,eq = ps.coeffs_qd(do_mc=True)        # Estimate quadratic law coefficients
 
 lnlike = ps.lnlike_qd([[0.45,0.15],      # Calculate the quadratic law log 
                        [0.35,0.10],      # likelihood for a set of coefficients 

--- a/src/core.py
+++ b/src/core.py
@@ -27,6 +27,7 @@ from cPickle import dump, load
 from numpy import (array, asarray, arange, linspace, zeros, zeros_like, ones, ones_like, delete,
                    diag, poly1d, polyfit, vstack, diff, cov, exp, log, sqrt, clip, pi, percentile)
 from numpy.random import normal, uniform, multivariate_normal
+from traitlets import TraitError
 
 ## Test if we're running inside IPython
 ## ------------------------------------
@@ -44,7 +45,7 @@ with warnings.catch_warnings():
         from IPython.html.widgets import IntProgress
         w = IntProgress()
         with_notebook = True
-    except (NameError,AttributeError,ImportError):
+    except (NameError,AttributeError,ImportError,TraitError):
         with_notebook = False
 
 ldtk_root  = os.getenv('LDTK_ROOT') or join(os.getenv('HOME'),'.ldtk')


### PR DESCRIPTION
The code would not run outside of a notebook with the latest version of IPython due to a "TraitError" that there is not an exception for in the with_notebook test, adding this exception enabled the code to run successfully on my system.