### PR TITLE
add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -60,4 +60,5 @@ preferred-citation:
   end: 3826
   volume: 453
   url : 'http://mnras.oxfordjournals.org/lookup/doi/10.1093/mnras/stv1857'
+  url: 'http://mnras.oxfordjournals.org/lookup/doi/10.1093/mnras/stv1857'
 license: GPL-2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,9 @@ authors:
     given-names: Suzanne
     orcid: 'https://orcid.org/0000-0003-1453-0574'
 identifiers:
-  - type: 'ascl-id'
+  - type: other
     value: '1510.003'
+    description: ascl
 repository-code: 'https://github.com/hpparvi/ldtk'
 abstract: >-
   We present a python package ldtk that automates the calculation of custom

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -42,6 +42,16 @@ keywords:
   - 'binaries: eclipsing'
 preferred-citation:
   type: article
+  title: >-
+    ldtk: Limb Darkening Toolkit
+  authors:
+    - family-names: Parviainen
+      given-names: Hannu
+      email: hannu.parviainen@physics.ox.ac.uk
+      orcid: 'https://orcid.org/0000-0001-5519-1391'
+    - family-names: Aigrain
+      given-names: Suzanne
+      orcid: 'https://orcid.org/0000-0003-1453-0574'
   doi: "10.1093/mnras/stv1857"
   journal: 'MNRAS'
   year: 2015

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,14 @@ title: >-
   ldtk: Limb Darkening Toolkit
 message: >-
   If you made the use of PyLDTk, I would appreciate it if you give credit.
-type: software
-date-released: 2015-09-10
+type: article
+journal: 'MNRAS'
+year: 2015
+month: 9
+day: 10
+start: 3821
+end: 3826
+volume: 453
 doi: 10.1093/mnras/stv1857
 authors:
   - family-names: 'Parviainen'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,6 +5,7 @@ message: >-
   If you made the use of PyLDTk, I would appreciate it if you give credit.
 type: software
 date-released: 2015-09-10
+doi: 10.1093/mnras/stv1857
 authors:
   - family-names: Parviainen
     given-names: Hannu
@@ -14,8 +15,6 @@ authors:
     given-names: Suzanne
     orcid: 'https://orcid.org/0000-0003-1453-0574'
 identifiers:
-  - type: 'doi'
-    value: '10.1093/mnras/stv1857'
   - type: 'ascl-id'
     value: '1510.003'
 repository-code: 'https://github.com/hpparvi/ldtk'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -55,7 +55,7 @@ preferred-citation:
   doi: "10.1093/mnras/stv1857"
   journal: 'MNRAS'
   year: 2015
-  month: 9
+  month: 11
   start: 3821
   end: 3826
   volume: 453

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,40 @@
+cff-version: 1.2.0
+title: >-
+  ldtk: Limb Darkening Toolkit
+message: >-
+  If you made the use of PyLDTk, I would appreciate it if you give credit.
+type: software
+date-released: 2015-09-10
+authors:
+  - family-names: Parviainen
+    given-names: Hannu
+    email: hannu.parviainen@physics.ox.ac.uk
+    orcid: 'https://orcid.org/0000-0001-5519-1391'
+  - family-names: Aigrain
+    given-names: Suzanne
+    orcid: 'https://orcid.org/0000-0003-1453-0574'
+identifiers:
+  - type: 'doi'
+    value: '10.1093/mnras/stv1857'
+  - type: 'ascl-id'
+    value: '1510.003'
+repository-code: 'https://github.com/hpparvi/ldtk'
+abstract: >-
+  We present a python package ldtk that automates the calculation of custom
+  stellar limb-darkening (LD) profiles and model-specific limb-darkening
+  coefficients using the library of phoenix-generated specific intensity
+  spectra by Husser et al. The aim of the package is to facilitate analyses
+  requiring custom generated LD profiles, such as the studies of exoplanet
+  transits -- especially transmission spectroscopy, where the transit modelling
+  is carried out for custom narrow passbands -- eclipsing binaries,
+  interferometry, and microlensing events. First, ldtk can be used to compute
+  custom LD profiles with uncertainties propagated from the uncertainties in
+  the stellar parameter estimates. Secondly, ldtk can be used to estimate the
+  LD-model-specific coefficients with uncertainties for the most common LD
+  models. Thirdly, ldtk can be directly integrated into the log posterior
+  computation of any pre-existing modelling code with minimal modifications.
+  The last approach can be used to constrain the LD model parameter space
+  directly by the LD profile, allowing for the marginalization over the LD
+  parameter space without the need to approximate the constraint from the LD
+  profile using a prior.
+license: GPL-2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,15 +3,6 @@ title: >-
   ldtk: Limb Darkening Toolkit
 message: >-
   If you made the use of PyLDTk, I would appreciate it if you give credit.
-type: article
-journal: 'MNRAS'
-year: 2015
-month: 9
-day: 10
-start: 3821
-end: 3826
-volume: 453
-doi: 10.1093/mnras/stv1857
 authors:
   - family-names: Parviainen
     given-names: Hannu
@@ -48,4 +39,14 @@ keywords:
   - 'techniques: interferometric'
   - 'planets and satellites: general'
   - 'binaries: eclipsing'
+preferred-citation:
+  type: article
+  doi: "10.1093/mnras/stv1857"
+  journal: 'MNRAS'
+  year: 2015
+  month: 9
+  day: 10
+  start: 3821
+  end: 3826
+  volume: 453
 license: GPL-2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -46,7 +46,6 @@ preferred-citation:
   journal: 'MNRAS'
   year: 2015
   month: 9
-  day: 10
   start: 3821
   end: 3826
   volume: 453

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,12 +7,12 @@ type: software
 date-released: 2015-09-10
 doi: 10.1093/mnras/stv1857
 authors:
-  - family-names: Parviainen
-    given-names: Hannu
+  - family-names: 'Parviainen'
+    given-names: 'Hannu'
     email: hannu.parviainen@physics.ox.ac.uk
     orcid: 'https://orcid.org/0000-0001-5519-1391'
-  - family-names: Aigrain
-    given-names: Suzanne
+  - family-names: 'Aigrain'
+    given-names: 'Suzanne'
     orcid: 'https://orcid.org/0000-0003-1453-0574'
 identifiers:
   - type: 'ascl-id'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -59,6 +59,7 @@ preferred-citation:
   start: 3821
   end: 3826
   volume: 453
-  url : 'http://mnras.oxfordjournals.org/lookup/doi/10.1093/mnras/stv1857'
+  number: 4
   url: 'http://mnras.oxfordjournals.org/lookup/doi/10.1093/mnras/stv1857'
+  abbreviation: Parviainen2015
 license: GPL-2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -42,4 +42,10 @@ abstract: >-
   directly by the LD profile, allowing for the marginalization over the LD
   parameter space without the need to approximate the constraint from the LD
   profile using a prior.
+keywords:
+  - 'gravitational lensing: micro'
+  - 'methods: numerical'
+  - 'techniques: interferometric'
+  - 'planets and satellites: general'
+  - 'binaries: eclipsing'
 license: GPL-2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,12 +13,12 @@ end: 3826
 volume: 453
 doi: 10.1093/mnras/stv1857
 authors:
-  - family-names: 'Parviainen'
-    given-names: 'Hannu'
+  - family-names: Parviainen
+    given-names: Hannu
     email: hannu.parviainen@physics.ox.ac.uk
     orcid: 'https://orcid.org/0000-0001-5519-1391'
-  - family-names: 'Aigrain'
-    given-names: 'Suzanne'
+  - family-names: Aigrain
+    given-names: Suzanne
     orcid: 'https://orcid.org/0000-0003-1453-0574'
 identifiers:
   - type: 'ascl-id'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -61,5 +61,4 @@ preferred-citation:
   volume: 453
   number: 4
   url: 'http://mnras.oxfordjournals.org/lookup/doi/10.1093/mnras/stv1857'
-  abbreviation: Parviainen2015
 license: GPL-2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -59,4 +59,5 @@ preferred-citation:
   start: 3821
   end: 3826
   volume: 453
+  url : 'http://mnras.oxfordjournals.org/lookup/doi/10.1093/mnras/stv1857'
 license: GPL-2.0


### PR DESCRIPTION
Adds a standard CITATION.cff file which (1) enriches the project metadata, (2) provides with a nice button:

![image](https://github.com/hpparvi/ldtk/assets/26519989/3dcbf07b-7467-4be7-ba95-d8eb7e35fca3)

The two supported formats are:
- APA
> Parviainen, H., & Aigrain, S. (2015). ldtk: Limb Darkening Toolkit. MNRAS, 453, 3821–3826. https://doi.org/10.1093/mnras/stv1857
- BibTeX
```bibtex
@article{Parviainen_ldtk_Limb_Darkening_2015,
author = {Parviainen, Hannu and Aigrain, Suzanne},
doi = {10.1093/mnras/stv1857},
journal = {MNRAS},
month = nov,
pages = {3821--3826},
title = {{ldtk: Limb Darkening Toolkit}},
url = {http://mnras.oxfordjournals.org/lookup/doi/10.1093/mnras/stv1857},
volume = {453},
year = {2015}
}
```

They are consistent with what is currently in the README (up to a different `bibtex` shorthand), so if you fancy this functionality and choose to add it, you might have to remove it from the README. I did my best to carry over the citation metadata properly, but I suggest that it is reviewed by you again.