### PR TITLE
Allowing custom path for _server_file_list

### DIFF
--- a/ldtk/client.py
+++ b/ldtk/client.py
@@ -88,7 +88,7 @@ class Client(object):
             self.fsize = 0.681
 
         self._cache = cache or join(ldtk_root, f'cache_{dataset}')
-        self._server_file_list = join(ldtk_root, f'server_file_list_{dataset}.pkl')
+        self._server_file_list = join(cache, f'server_file_list_{dataset}.pkl') if cache is not None else join(ldtk_root, f'server_file_list_{dataset}.pkl')
 
         if not exists(self._cache):
             os.mkdir(self._cache)


### PR DESCRIPTION
While working on a remote desktop with limited permissions, this will allow the user to set a custom path for _server_file_list.